### PR TITLE
Cedric: Correct fps in .prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -76,7 +76,7 @@ vendor.vidc.dec.downscalar_width=1920
 vendor.vidc.dec.downscalar_height=1088
 media.camera.ts.monotonic=1
 persist.camera.time.monotonic=1
-persist.camera.max.previewfps=60
+persist.camera.max.previewfps=30
 
 # CNE
 persist.cne.feature=1


### PR DESCRIPTION
The snapdragon 430 enables us to record at 30@1080p but not 60@1080 therefore this is correct and should fix recording on cameras like gcam which use this preset