### PR TITLE
cedric: Default to 1GB swap on all variants

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -18,4 +18,4 @@
 /dev/block/bootdevice/by-name/misc           /misc        emmc    defaults                                                                           defaults
 /devices/soc/7864900.sdhci/mmc_host*         auto         auto    nosuid,nodev                                                                       wait,voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/soc/78db000.usb/msm_hsusb_host*     auto         auto    defaults                                                                           voldmanaged=usb:auto
-/dev/block/zram0                             none         swap    defaults                                                                           zramsize=536870912,max_comp_streams=4
+/dev/block/zram0                             none         swap    defaults                                                                            zramsize=1073741824,max_comp_streams=4

--- a/rootdir/etc/init.cedric.rc
+++ b/rootdir/etc/init.cedric.rc
@@ -29,9 +29,3 @@ on property:sys.boot_completed=1
     # Enable ZRAM on boot_complete
     swapon_all /system/vendor/etc/fstab.qcom
     write /proc/sys/vm/swappiness 100
-
-on property:ro.boot.ram=2GB
-    write /sys/block/zram0/disksize 536870912
-
-on property:ro.boot.ram=3GB
-    write /sys/block/zram0/disksize 805306368


### PR DESCRIPTION
Improves ram management greatly.

Signed-off-by: Vaisakh Murali <vaisakhmurali@gmail.com>