### PR TITLE
cedric: sepolicy: Add HID Gadget Rules

### DIFF
--- a/sepolicy/apexd.te
+++ b/sepolicy/apexd.te
@@ -1,1 +1,2 @@
 allow apexd device:file { open write };
+allow appdomain hid_gadget_device:chr_file rw_file_perms;

--- a/sepolicy/apexd.te
+++ b/sepolicy/apexd.te
@@ -1,2 +1,1 @@
 allow apexd device:file { open write };
-allow appdomain hid_gadget_device:chr_file rw_file_perms;

--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -9,3 +9,4 @@ type laser_device, dev_type;
 type synaptics_rmi_device, dev_type;
 type shwi_device, dev_type;
 type utags_block_device, dev_type;
+type hid_gadget_device, dev_type;

--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -9,4 +9,4 @@ type laser_device, dev_type;
 type synaptics_rmi_device, dev_type;
 type shwi_device, dev_type;
 type utags_block_device, dev_type;
-type hid_gadget_device, dev_type;
+type hid_gadget_device, dev_type, mlstrustedsubject;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -148,3 +148,6 @@
 /bt_firmware(/.*)?       u:object_r:bt_firmware_file:s0
 /firmware(/.*)?          u:object_r:firmware_file:s0
 /fsg(/.*)?               u:object_r:fsg_file:s0
+
+# USB Gadget
+/dev/hidg(.*)                        u:object_r:hid_gadget_device:s0

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -9,4 +9,4 @@ allow untrusted_app fsg_file:dir read;
 allow untrusted_app proc_asound:dir search;
 allow untrusted_app proc_qtaguid_stat:file read;
 
-allow untrusted_app hid_gadget_device:chr_file *;
+allow untrusted_app hid_gadget_device:chr_file rw_file_perms;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -8,3 +8,5 @@ allow untrusted_app fsg_file:dir read;
 
 allow untrusted_app proc_asound:dir search;
 allow untrusted_app proc_qtaguid_stat:file read;
+
+allow untrusted_app hid_gadget_device:chr_file write;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -9,4 +9,4 @@ allow untrusted_app fsg_file:dir read;
 allow untrusted_app proc_asound:dir search;
 allow untrusted_app proc_qtaguid_stat:file read;
 
-allow untrusted_app hid_gadget_device:chr_file rw_file_perms;
+allow appdomain hid_gadget_device:chr_file rw_file_perms;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -9,4 +9,4 @@ allow untrusted_app fsg_file:dir read;
 allow untrusted_app proc_asound:dir search;
 allow untrusted_app proc_qtaguid_stat:file read;
 
-allow untrusted_app hid_gadget_device:chr_file write;
+allow untrusted_app hid_gadget_device:chr_file *;


### PR DESCRIPTION
The HID Gadget driver exists in the current kernel but is disabled. If
you ever want to enable it sepolicy is already there. Another reason: If
a user wants this, they do not need to recompile the ROM but only the
kernel.